### PR TITLE
Update dependencies and enhance block rendering support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "notion-to-jarkup"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jarkup-rs"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2649cac91ce311635a2526fb6b8e0d86238d48c90b51fb13bec55dcd1a87c902"
+checksum = "6c51bd0a02948d665e8e07b118a255736c9ee95a8e8efb38cdb2387dc48bc193"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "./README.md"
 [dependencies]
 async-recursion = "1.1.1"
 html-meta-scraper = "0.1.0"
-jarkup-rs = "0.1.2"
+jarkup-rs = "0.2.2"
 notionrs = "1.0.0-alpha.40"
 reqwest = { version = "0.12.15", default-features = false, features = [
     "rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notion-to-jarkup"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Convert Notion blocks into jarkup JSON."
 authors = ["Chomolungma Shirayuki"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,9 +2,23 @@
 pub struct Client {
     pub notionrs_client: notionrs::client::Client,
     pub reqwest_client: reqwest::Client,
+
+    /// If true, unsupported blocks will be rendered as `Unsupported` blocks.
+    /// If false, unsupported blocks will be skipped.
+    pub enable_unsupported_block: bool,
 }
 
 impl Client {
+    fn create_unsupported_component(&self, bloack_name: &str) -> jarkup_rs::Component {
+        jarkup_rs::Unsupported {
+            props: Some(jarkup_rs::UnsupportedProps {
+                details: format!("Notion: `{} Block` is not supported.", bloack_name),
+            }),
+            slots: None,
+        }
+        .into()
+    }
+
     #[async_recursion::async_recursion]
     pub async fn convert_block(
         &self,
@@ -21,7 +35,13 @@ impl Client {
 
         for block in blocks {
             match block.block {
-                notionrs::object::block::Block::Audio { audio: _ } => continue,
+                notionrs::object::block::Block::Audio { audio: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Audio"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::Bookmark { bookmark } => {
                     let html = self
                         .reqwest_client
@@ -49,7 +69,13 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::Breadcrumb { breadcrumb: _ } => continue,
+                notionrs::object::block::Block::Breadcrumb { breadcrumb: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Breadcrumb"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::BulletedListItem { bulleted_list_item } => {
                     let list_item_component = jarkup_rs::ListItem {
                         props: None,
@@ -171,8 +197,20 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::ChildDatabase { child_database: _ } => continue,
-                notionrs::object::block::Block::ChildPage { child_page: _ } => continue,
+                notionrs::object::block::Block::ChildDatabase { child_database: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("ChildDatabase"));
+                    } else {
+                        continue;
+                    }
+                }
+                notionrs::object::block::Block::ChildPage { child_page: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("ChildPage"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::Code { code } => {
                     let component = jarkup_rs::CodeBlock {
                         props: jarkup_rs::CodeBlockProps {
@@ -202,7 +240,13 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::Embed { embed: _ } => continue,
+                notionrs::object::block::Block::Embed { embed: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Embed"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::Equation { equation } => {
                     let component = jarkup_rs::Katex {
                         props: jarkup_rs::KatexProps {
@@ -288,7 +332,13 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::LinkPreview { link_preview: _ } => continue,
+                notionrs::object::block::Block::LinkPreview { link_preview: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("LinkPreview"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::NumberedListItem { numbered_list_item } => {
                     let list_item_component = jarkup_rs::ListItem {
                         props: None,
@@ -386,7 +436,13 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::SyncedBlock { synced_block: _ } => continue,
+                notionrs::object::block::Block::SyncedBlock { synced_block: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("SyncedBlock"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::TableOfContents {
                     table_of_contents: _,
                 } => continue,
@@ -465,8 +521,20 @@ impl Client {
                         components.push(component.into());
                     }
                 }
-                notionrs::object::block::Block::Template { template: _ } => continue,
-                notionrs::object::block::Block::ToDo { to_do: _ } => continue,
+                notionrs::object::block::Block::Template { template: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Template"));
+                    } else {
+                        continue;
+                    }
+                }
+                notionrs::object::block::Block::ToDo { to_do: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("ToDo"));
+                    } else {
+                        continue;
+                    }
+                }
                 notionrs::object::block::Block::Toggle { toggle } => {
                     let children_components = if block.has_children {
                         self.convert_block(&block.id).await?
@@ -486,8 +554,20 @@ impl Client {
 
                     components.push(component.into());
                 }
-                notionrs::object::block::Block::Video { video: _ } => continue,
-                notionrs::object::block::Block::Unsupported => continue,
+                notionrs::object::block::Block::Video { video: _ } => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Video"));
+                    } else {
+                        continue;
+                    }
+                }
+                notionrs::object::block::Block::Unsupported => {
+                    if self.enable_unsupported_block {
+                        components.push(self.create_unsupported_component("Unsupported"));
+                    } else {
+                        continue;
+                    }
+                }
             }
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,10 +9,10 @@ pub struct Client {
 }
 
 impl Client {
-    fn create_unsupported_component(&self, bloack_name: &str) -> jarkup_rs::Component {
+    fn create_unsupported_component(&self, block_name: &str) -> jarkup_rs::Component {
         jarkup_rs::Unsupported {
             props: Some(jarkup_rs::UnsupportedProps {
-                details: format!("Notion: `{} Block` is not supported.", bloack_name),
+                details: format!("Notion: `{} Block` is not supported.", block_name),
             }),
             slots: None,
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,6 @@ impl Client {
                     let image = meta_scraper.image();
 
                     let component = jarkup_rs::Bookmark {
-                        inline: false,
                         props: jarkup_rs::BookmarkProps {
                             url: bookmark.url,
                             title,
@@ -53,7 +52,6 @@ impl Client {
                 notionrs::object::block::Block::Breadcrumb { breadcrumb: _ } => continue,
                 notionrs::object::block::Block::BulletedListItem { bulleted_list_item } => {
                     let list_item_component = jarkup_rs::ListItem {
-                        inline: false,
                         props: None,
                         slots: jarkup_rs::ListItemSlots {
                             default: self.convert_rich_text(bulleted_list_item.rich_text).await?,
@@ -94,7 +92,6 @@ impl Client {
                     };
 
                     let component = jarkup_rs::List {
-                        inline: false,
                         props: Some(jarkup_rs::ListProps {
                             list_style: Some(jarkup_rs::ListStyle::Unordered),
                         }),
@@ -110,7 +107,6 @@ impl Client {
                         if callout.rich_text.len() > 0 {
                             Some(
                                 jarkup_rs::Paragraph {
-                                    inline: false,
                                     props: None,
                                     slots: jarkup_rs::ParagraphSlots {
                                         default: self.convert_rich_text(callout.rich_text).await?,
@@ -134,7 +130,6 @@ impl Client {
                         .collect::<Vec<jarkup_rs::Component>>();
 
                     let component = jarkup_rs::Callout {
-                        inline: false,
                         props: Some(jarkup_rs::CalloutProps {
                             r#type: Some(match callout.color {
                                 notionrs::object::color::Color::Default
@@ -180,7 +175,6 @@ impl Client {
                 notionrs::object::block::Block::ChildPage { child_page: _ } => continue,
                 notionrs::object::block::Block::Code { code } => {
                     let component = jarkup_rs::CodeBlock {
-                        inline: false,
                         props: jarkup_rs::CodeBlockProps {
                             code: code
                                 .rich_text
@@ -191,9 +185,9 @@ impl Client {
                                 .join(""),
                             language: code.language.to_string(),
                         },
-                        slots: jarkup_rs::CodeBlockSlots {
+                        slots: Some(jarkup_rs::CodeBlockSlots {
                             default: self.convert_rich_text(code.caption).await?,
-                        },
+                        }),
                     };
 
                     components.push(component.into());
@@ -202,7 +196,6 @@ impl Client {
                 notionrs::object::block::Block::Column { column: _ } => continue,
                 notionrs::object::block::Block::Divider { divider: _ } => {
                     let component = jarkup_rs::Divider {
-                        inline: false,
                         props: None,
                         slots: None,
                     };
@@ -212,7 +205,6 @@ impl Client {
                 notionrs::object::block::Block::Embed { embed: _ } => continue,
                 notionrs::object::block::Block::Equation { equation } => {
                     let component = jarkup_rs::Katex {
-                        inline: false,
                         props: jarkup_rs::KatexProps {
                             expression: equation.expression,
                         },
@@ -223,7 +215,6 @@ impl Client {
                 }
                 notionrs::object::block::Block::File { file } => {
                     let component = jarkup_rs::File {
-                        inline: false,
                         props: jarkup_rs::FileProps {
                             src: file.get_url(),
                             name: match file {
@@ -242,7 +233,6 @@ impl Client {
                 }
                 notionrs::object::block::Block::Heading1 { heading_1 } => {
                     let component = jarkup_rs::Heading {
-                        inline: false,
                         props: jarkup_rs::HeadingProps {
                             level: jarkup_rs::HeadingLevel::H1,
                         },
@@ -255,7 +245,6 @@ impl Client {
                 }
                 notionrs::object::block::Block::Heading2 { heading_2 } => {
                     let component = jarkup_rs::Heading {
-                        inline: false,
                         props: jarkup_rs::HeadingProps {
                             level: jarkup_rs::HeadingLevel::H2,
                         },
@@ -268,7 +257,6 @@ impl Client {
                 }
                 notionrs::object::block::Block::Heading3 { heading_3 } => {
                     let component = jarkup_rs::Heading {
-                        inline: false,
                         props: jarkup_rs::HeadingProps {
                             level: jarkup_rs::HeadingLevel::H3,
                         },
@@ -291,7 +279,6 @@ impl Client {
                     .map(|c| c.into_iter().map(|r| r.to_string()).collect::<String>());
 
                     let component = jarkup_rs::Image {
-                        inline: false,
                         props: jarkup_rs::ImageProps {
                             src: image.get_url(),
                             alt: maybe_caption,
@@ -304,7 +291,6 @@ impl Client {
                 notionrs::object::block::Block::LinkPreview { link_preview: _ } => continue,
                 notionrs::object::block::Block::NumberedListItem { numbered_list_item } => {
                     let list_item_component = jarkup_rs::ListItem {
-                        inline: false,
                         props: None,
                         slots: jarkup_rs::ListItemSlots {
                             default: self.convert_rich_text(numbered_list_item.rich_text).await?,
@@ -345,7 +331,6 @@ impl Client {
                     };
 
                     let component = jarkup_rs::List {
-                        inline: false,
                         props: Some(jarkup_rs::ListProps {
                             list_style: Some(jarkup_rs::ListStyle::Ordered),
                         }),
@@ -358,7 +343,6 @@ impl Client {
                 }
                 notionrs::object::block::Block::Paragraph { paragraph } => {
                     let component = jarkup_rs::Paragraph {
-                        inline: false,
                         props: None,
                         slots: jarkup_rs::ParagraphSlots {
                             default: self.convert_rich_text(paragraph.rich_text).await?,
@@ -372,7 +356,6 @@ impl Client {
                     let maybe_paragraph_component: Option<jarkup_rs::Component> =
                         if quote.rich_text.len() > 0 {
                             let paragraph = jarkup_rs::Paragraph {
-                                inline: false,
                                 props: None,
                                 slots: jarkup_rs::ParagraphSlots {
                                     default: self.convert_rich_text(quote.rich_text).await?,
@@ -395,7 +378,6 @@ impl Client {
                         .collect::<Vec<jarkup_rs::Component>>();
 
                     let component = jarkup_rs::BlockQuote {
-                        inline: false,
                         props: None,
                         slots: jarkup_rs::BlockQuoteSlots {
                             default: merged_components,
@@ -456,7 +438,6 @@ impl Client {
                         .collect::<Vec<jarkup_rs::Component>>();
 
                     let component = jarkup_rs::Table {
-                        inline: false,
                         props: Some(jarkup_rs::TableProps {
                             has_column_header: Some(table.has_column_header),
                             has_row_header: Some(table.has_row_header),
@@ -475,7 +456,6 @@ impl Client {
                         let children_inline_componense = self.convert_rich_text(cell).await?;
 
                         let component = jarkup_rs::TableCell {
-                            inline: false,
                             props: None,
                             slots: jarkup_rs::TableCellSlots {
                                 default: children_inline_componense,
@@ -497,7 +477,6 @@ impl Client {
                     let summary_components = self.convert_rich_text(toggle.rich_text).await?;
 
                     let component = jarkup_rs::Toggle {
-                        inline: false,
                         props: None,
                         slots: jarkup_rs::ToggleSlots {
                             default: children_components,
@@ -531,7 +510,6 @@ impl Client {
                     href: _,
                 } => {
                     let component = jarkup_rs::Text {
-                        inline: true,
                         props: jarkup_rs::TextProps {
                             text: plain_text,
                             color: match annotations.color {
@@ -638,7 +616,6 @@ impl Client {
                                 link_mention,
                             } => {
                                 let component = jarkup_rs::Text {
-                                    inline: true,
                                     props: jarkup_rs::TextProps {
                                         text: plain_text,
                                         favicon: self
@@ -671,7 +648,6 @@ impl Client {
                                 custom_emoji,
                             } => {
                                 let component = jarkup_rs::Icon {
-                                    inline: true,
                                     props: jarkup_rs::IconProps {
                                         src: custom_emoji.url,
                                         alt: Some(custom_emoji.name),
@@ -694,7 +670,6 @@ impl Client {
                     href: _href,
                 } => {
                     let component = jarkup_rs::Text {
-                        inline: true,
                         props: jarkup_rs::TextProps {
                             text: equation.expression,
                             katex: Some(true),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -10,6 +10,7 @@ async fn convert() -> Result<(), Box<dyn std::error::Error>> {
     let client = notion_to_jarkup::client::Client {
         notionrs_client,
         reqwest_client,
+        enable_unsupported_block: true,
     };
 
     let result = client.convert_block(&block_id).await?;


### PR DESCRIPTION
Upgrade the jarkup-rs dependency and improve the handling of unsupported blocks and table components. Bump the package version to 0.2.0.